### PR TITLE
generate passwords from machine ID and allow changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ restic_backups:
     timeout: 120
     enabled: true
 ```
-The `restic_repo_master_pass` is used to generate a per-host password using hostname as a salt.
+The `restic_repo_master_pass` is used to generate a per-host password using [machine ID](https://man7.org/linux/man-pages/man5/machine-id.5.html) as a salt.
+
+Password changing is disabled by default, but can be enabled with `restic_repo_pass_allow_change: true`.
 
 # Management
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ restic_repo_pass: >-
   {{ restic_repo_master_pass | mandatory
   | password_hash('sha512', (inventory_hostname|hash('sha1'))[0:16], rounds=5000)
   | string }}
+# If necessary set this to true to allow repo password change.
+restic_repo_pass_allow_change: false
 restic_repo_pass_file: '{{ restic_user_home }}/.restic_pass'
 
 # Maximum number of backups to keep for each type.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,11 @@ restic_cache_path: '{{ restic_user_home }}/.cache/restic'
 # This password encrypts the repository repo pass.
 #restic_repo_master_pass:
 # We generate password by hashing the master pasword with SHA512
-# using a slice of the hostname SHA1 as salt.
+# using a slice of the machine ID as salt.
 # Should give you the same password on the same host.
 restic_repo_pass: >-
   {{ restic_repo_master_pass | mandatory
-  | password_hash('sha512', (inventory_hostname|hash('sha1'))[0:16], rounds=5000)
+  | password_hash('sha512', (ansible_machine_id)[0:16], rounds=5000)
   | string }}
 # If necessary set this to true to allow repo password change.
 restic_repo_pass_allow_change: false

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -32,6 +32,7 @@
     systemd_timer_consul_service_name: 'restic-backup'
     systemd_timer_consul_extra_tags: ['backup', 'restic']
     systemd_timer_consul_meta:
+      version:          '{{ restic_version }}'
       backup_repo:      '{{ restic_repo_path }}'
       backup_name:      '{{ backup.name      | mandatory }}'
       backup_docs:      '{{ backup.docs      | default(restic_backup_default_docs_url) }}'

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -1,0 +1,32 @@
+---
+- name: Check if password file exists
+  stat:
+    path: '{{ restic_repo_pass_file }}'
+  register: restic_repo_pass_file_stat
+
+- name: Read current password file
+  slurp:
+    path: '{{ restic_repo_pass_file }}'
+  register: restic_pass_file_raw
+  when: restic_repo_pass_file_stat.stat.exists
+
+- name: Decode password from file
+  set_fact:
+    restic_repo_pass_old: '{{ restic_pass_file_raw.content | b64decode | trim }}'
+  when: restic_repo_pass_file_stat.stat.exists
+
+- name: Check if password file has changed
+  fail:
+    msg: |
+      ERROR: The repo password has changed!
+
+      This should normally not happen. Either:
+
+        - Machine ID has changed.
+        - Master password has changed.
+
+      Set 'restic_repo_pass_allow_change' if necessary.
+  when: |
+    restic_repo_pass_file_stat.stat.exists
+    and not restic_repo_pass_allow_change
+    and restic_repo_pass_old != restic_repo_pass

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -7,6 +7,16 @@
     state: 'directory'
     mode: 0700
 
+- name: Change password of Restic repo
+  when: restic_repo_pass_old != restic_repo_pass
+  command: |
+    restic key passwd --new-password-file={{ restic_repo_pass_file }}
+  become_user: '{{ restic_user_name }}'
+  environment:
+    RESTIC_REPOSITORY: '{{ restic_repo_path }}'
+    RESTIC_PASSWORD_FILE: '{{ restic_repo_pass_file_copy.backup_file }}'
+    RESTIC_CACHE_DIR: '{{ restic_cache_path }}'
+
 - name: Initialize the Restic repo
   command:
     cmd: 'restic init'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - import_tasks: install.yml
+- import_tasks: check.yml
 - import_tasks: user.yml
 - import_tasks: pass.yml
 - import_tasks: init.yml
@@ -7,7 +8,7 @@
 - import_tasks: pruning.yml
   when: restic_pruning_enabled
 
-- include_tasks: ./backup.yml
+- include_tasks: backup.yml
   with_items: '{{ restic_backups }}'
   loop_control:
     loop_var: backup

--- a/tasks/pass.yml
+++ b/tasks/pass.yml
@@ -1,40 +1,14 @@
 ---
-- name: Check if password file exists
-  stat:
-    path: '{{ restic_repo_pass_file }}'
-  register: restic_pass_file_stat
-
-- name: Read current password file
-  slurp:
-    path: '{{ restic_repo_pass_file }}'
-  register: restic_pass_file_raw
-  when: restic_pass_file_stat.stat.exists
-
-- name: Decode password from file
-  set_fact:
-    restic_repo_pass_old: '{{ restic_pass_file_raw.content | b64decode | trim }}'
-  when: restic_pass_file_stat.stat.exists
-
-- name: Check if password file has changed
-  fail:
-    msg: |
-      The password has changed! This should not happen!
-      This can be caused by hostname change.
-      You might have to re-initialize the repository.
-  when: |
-    restic_pass_file_stat.stat.exists
-    and restic_repo_pass_old != restic_repo_pass
-
 - name: Create password file
   copy:
-    dest: '{{ restic_repo_pass_file }}'
+    dest:    '{{ restic_repo_pass_file }}'
     content: '{{ restic_repo_pass | mandatory }}'
-    owner: '{{ restic_user_name }}'
-    group: '{{ restic_user_name }}'
-    mode: 0600
+    owner:   '{{ restic_user_name }}'
+    group:   '{{ restic_user_name }}'
+    mode:    0600
     # THIS IS VERY IMPORTANT IN CASE OF PASSWORD CHANGE
     backup: true
-  register: restic_pass_file_copy
+  register: restic_repo_pass_file_copy
 
 # To simplify use with `sudo -iu restic ...`
 - name: Create bashrc file


### PR DESCRIPTION
Because using hostname is causing issues frequently, and machine ID should not.

Related:
- [`infra-role-bootstrap-linux#e93039e0`](https://github.com/status-im/infra-role-bootstrap-linux/commit/e93039e0) - consul: add machine ID to node metadata
- [`infra-role-bootstrap-linux#c2bb9583`](https://github.com/status-im/infra-role-bootstrap-linux/commit/c2bb9583) - system: re-generate machine ID on Alibaba Cloud hosts