### PR TITLE
pruning: add restic prune to cleanup hanging files

### DIFF
--- a/tasks/pruning.yml
+++ b/tasks/pruning.yml
@@ -18,6 +18,8 @@
       --compact
       --retry-lock {{ restic_pruning_retry_lock }}
       --keep-last {{ restic_pruning_retention }}
+    systemd_timer_exec_stop_post:
+      - '{{ restic_binary_path }} prune'
     systemd_timer_environment:
       RESTIC_REPOSITORY: '{{ restic_repo_path }}'
       RESTIC_PASSWORD_FILE: '{{ restic_repo_pass_file }}'


### PR DESCRIPTION
40.338 GiB were cleane up from `node-01.do-ams3.matrix.logos`, which were not cleaned by `restic forget --prune`:
```
❯ sudo -iu restic restic prune
-bash: warning: setlocale: LC_ALL: cannot change locale (en_GB.UTF-8)
repository bf52dfa2 opened (version 2, compression level auto)
loading indexes...
[0:00] 100.00%  1 / 1 index files loaded
loading all snapshots...
finding data that is still in use for 2 snapshots
[0:00] 100.00%  2 / 2 snapshots
searching used packs...
collecting packs for deletion and repacking
[0:00] 100.00%  785 / 785 packs processed

to repack:             0 blobs / 0 B
this removes:          0 blobs / 0 B
to delete:             0 blobs / 40.338 GiB
total prune:           0 blobs / 40.338 GiB
remaining:         10039 blobs / 12.968 GiB
unused size after prune: 657.323 MiB (4.95% of remaining size)

deleting unreferenced packs
[0:00] 100.00%  2418 / 2418 files deleted
done
```