### PR TITLE
script: move creation of backup-check script to init

### DIFF
--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -28,3 +28,11 @@
     RESTIC_REPOSITORY: '{{ restic_repo_path }}'
     RESTIC_PASSWORD_FILE: '{{ restic_repo_pass_file }}'
     RESTIC_CACHE_DIR: '{{ restic_cache_path }}'
+
+- name: Create backup size check script
+  template:
+    src: 'backup-check-script.sh.j2'
+    dest: '{{ restic_backup_size_check_script }}'
+    owner: '{{ restic_user_name }}'
+    group: '{{ restic_user_name }}'
+    mode: 0775

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,10 +14,3 @@
     path: '{{ restic_binary_path }}'
     mode: 0755
 
-- name: Create backup size check script
-  template:
-    src: 'backup-check-script.sh.j2'
-    dest: '{{ restic_backup_size_check_script }}'
-    owner: '{{ restic_user_name }}'
-    group: '{{ restic_user_name }}'
-    mode: 0775


### PR DESCRIPTION
The file is created with owner restic before the user restic exists.