### PR TITLE
backup: add post run check of snapshot size

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ restic_ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA6mu...'
 
 # Configuration of individual backups
 restic_backups:
+  - name: 'app-xyz-files'
+    path: '/docker/app-xyz/files'
+    tags: ['directory']
+
+    # Most fields are optional
   - name: 'app-xyz-postgres'
     tags: ['pgdumpdir']
     path: '/docker/app-xyz/db/backup'
@@ -19,7 +24,12 @@ restic_backups:
     requires: 'dump-xyz-db.service'
     after: 'dump-xyz-db.service'
     frequency: 'daily'
+    timeout: 120
     restart: 'no'
+    restart_retries: 3
+    min_bytes: 200000
+    min_files: 2
+    restart_retries: 3
     timeout: 120
     enabled: true
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ restic_bz2_url: 'https://github.com/restic/restic/releases/download/v{{ restic_v
 restic_bz2_sha256: 'bdfaf16fe933136e3057e64e28624f2e0451dbd47e23badb2d37dbb60fdb6a70'
 restic_binary_path: '/usr/local/bin/restic'
 restic_backup_size_check_script: '/usr/local/bin/backup-check-script.sh'
+restic_snapshot_check_script: '/usr/local/bin/snapshot-restic-check.sh'
 
 # Default values for unset settings in restic_backups objects.
 restic_backup_default_frequency: 'daily'
@@ -53,8 +54,10 @@ restic_backup_default_docs_url: 'https://github.com/status-im/infra-role-restic-
 # Do no create a snapshot if nothing changed.
 backup_skip_if_unchanged: true
 
-# backups should be larger than 512 KB
-backup_size_threshold_bytes: 512000
+# Backups and snapshots should be larger than 512 KB
+backup_min_bytes_processed: 512000
+# and need to process more than one file
+backup_min_files_processed: 1
 
 # list of objects that define resources to back up
 restic_backups: []
@@ -67,6 +70,9 @@ restic_backups: []
 #    frequency: 'daily'
 #    timeout: 120
 #    restart: 'no'
+#    restart_retries: 3
+#    min_bytes: 200000
+#    min_files: 2
 #    restart_retries: 3
 #    timeout: 120
 #    enabled: true

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -19,7 +19,8 @@
     # Script Configuration
     systemd_timer_work_dir: '{{ restic_repo_path }}'
     systemd_timer_script_path: '{{ restic_binary_path }}'
-    systemd_timer_exec_start_pre: ['{{ restic_backup_size_check_script }} {{ backup.path | join("") }}']
+    systemd_timer_exec_start_pre:
+      - '{{ restic_backup_size_check_script }} {{ backup.path }}'
     systemd_timer_script_args: >-
       backup --tag {{ backup.tags | default([]) | join("\n") }}
       {% if backup_skip_if_unchanged %}--skip-if-unchanged{% endif %}
@@ -27,6 +28,12 @@
       --exclude '{{ exclude }}'
       {% endfor %}
       {{ backup.path | mandatory }}
+    systemd_timer_exec_stop_post:
+      - >-
+        {{ restic_snapshot_check_script }}
+        '--path={{ backup.path }} --host={{ inventory_hostname }} --latest=1'
+        {{ backup.min_bytes | default("") }}
+        {{ backup.min_files | default("") }}
     systemd_timer_environment:
       RESTIC_REPOSITORY: '{{ restic_repo_path }}'
       RESTIC_PASSWORD_FILE: '{{ restic_repo_pass_file }}'

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -31,8 +31,16 @@
 
 - name: Create backup size check script
   template:
-    src: 'backup-check-script.sh.j2'
-    dest: '{{ restic_backup_size_check_script }}'
+    src:   'backup-check-script.sh.j2'
+    dest:  '{{ restic_backup_size_check_script }}'
+    owner: '{{ restic_user_name }}'
+    group: '{{ restic_user_name }}'
+    mode: 0775
+
+- name: Create snapshot size check script
+  template:
+    src:   'snapshot-restic-check.sh.j2'
+    dest:  '{{ restic_snapshot_check_script }}'
     owner: '{{ restic_user_name }}'
     group: '{{ restic_user_name }}'
     mode: 0775

--- a/templates/backup-check-script.sh.j2
+++ b/templates/backup-check-script.sh.j2
@@ -2,17 +2,23 @@
 # vim: ft=sh
 set -e
 
-if [ -z "$1" ]; then
-    echo "Error: Backup directory path required"
+BACKUP_DIR="${1}"
+MIN_BYTES="${2:-{{ backup_min_bytes_processed }}}"
+MIN_FILES="${3:-{{ backup_min_files_processed }}}"
+
+if [[ -z "${BACKUP_DIR}" ]]; then
+    echo "ERROR: Backup directory path required"
     exit 1
 fi
+DIR_BYTES=$(du -bs "${BACKUP_DIR}" | cut -f1)
+DIR_FILES=$(find "${BACKUP_DIR}" -type f | wc -l)
 
-BACKUP_DIR="$1"
-MIN_SIZE_BYTES="{{ backup_size_threshold_bytes }}"
-
-DIR_SIZE=$(du -bs "${BACKUP_DIR}" | cut -f1)
-
-if [ "${DIR_SIZE}" -lt "${MIN_SIZE_BYTES}" ]; then
-    echo "Error: Backup directory too small (${DIR_SIZE} bytes), minimum size is ${MIN_SIZE_BYTES} bytes"
+if [[ ${DIR_BYTES} -lt ${MIN_BYTES} ]]; then
+    echo "ERROR: Dir too small (${DIR_BYTES} B), minimum size is ${MIN_SIZE_BYTES} B." >&2
     exit 1
 fi
+if [[ ${DIR_FILES} -lt ${MIN_FILES} ]]; then
+    echo "ERROR: Dir with not enough files (${DIR_FILES}), minimum number is ${MIN_FILES}." >&2
+    exit 1
+fi
+echo "CHECK: No backup dir issues found."

--- a/templates/snapshot-restic-check.sh.j2
+++ b/templates/snapshot-restic-check.sh.j2
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# vim: ft=sh
+set -e
+
+RESTIC_QUERY_FLAGS="${1:---host=${HOST} --latest=1}"
+SNAPSHOT_JSON=$(restic --json snapshots ${RESTIC_QUERY_FLAGS})
+
+MIN_BYTES="${2:-{{ backup_min_bytes_processed }}}"
+MIN_FILES="${3:-{{ backup_min_files_processed }}}"
+TOTAL_BYTES=$(echo "${SNAPSHOT_JSON}" | jq '.[].summary.total_bytes_processed')
+TOTAL_FILES=$(echo "${SNAPSHOT_JSON}" | jq '.[].summary.total_files_processed')
+
+if [[ "${TOTAL_BYTES}" == *$'\n'* ]]; then
+    echo "ERROR: More than one snapshot discovered, unable to check." >&2
+    exit 1
+fi
+if [[ ${TOTAL_BYTES} -lt ${MIN_BYTES} ]]; then
+    echo "ERROR: Snapshot too small (${TOTAL_BYTES} bytes), minimum size is ${MIN_BYTES} bytes." >&2
+    exit 1
+fi
+if [[ ${TOTAL_FILES} -lt ${MIN_FILES} ]]; then
+    echo "ERROR: Snapshot with not enough files (${TOTAL_FILES}), minimum files is ${MIN_FILES}." >&2
+    exit 1
+fi
+echo "CHECK: No snapshot issues found."


### PR DESCRIPTION
Also consolidate variables for pre and post check.

Example:
```
Starting Backup of synapse-db with Restic...
CHECK: No backup dir issues found.
using parent snapshot a788efef
Files:           0 new,     0 changed,   172 unmodified
Dirs:            0 new,     0 changed,     5 unmodified
Added to the repository: 0 B   (0 B   stored)
processed 172 files, 3.748 GiB in 0:00
skipped creating snapshot
CHECK: No snapshot issues found.
backup-synapse-db.service: Deactivated successfully.
Finished Backup of synapse-db with Restic.
```

Related posmortem:
- https://github.com/status-im/infra-docs/pull/42